### PR TITLE
test: fixing within map check

### DIFF
--- a/pkg/validation/Validate_test.go
+++ b/pkg/validation/Validate_test.go
@@ -2461,9 +2461,6 @@ func TestValidateEachEq(t *testing.T) {
 								"Kurt Donald Cobain",
 								"David Eric Grohl",
 							},
-							"Metallica": {
-								"Lars Ulrich",
-							},
 						},
 					})
 
@@ -5022,9 +5019,6 @@ func TestValidateEachMax(t *testing.T) {
 							"Nirvana": {
 								"Kurt Donald Cobain",
 								"David Eric Grohl",
-							},
-							"Metallica": {
-								"Lars Ulrich",
 							},
 						},
 					})


### PR DESCRIPTION
We should be careful with the map and avoid multiple different errors in the same test, as this behavior breaks the tests